### PR TITLE
Update processing time in openWay.js packager

### DIFF
--- a/lib/iso8583/lib/packager/openWay.js
+++ b/lib/iso8583/lib/packager/openWay.js
@@ -212,7 +212,7 @@ exports.format = {
   '12': {
     length: 3,
     name:   'Processing Time',
-    type:   'bn',
+    type:   'b',
     alias:  ''
   },
   '13': {


### PR DESCRIPTION
when integrating with Openway vendor, I noticed following error
Error: Cannot find module './packer/bn'

With this fix I was able to avoid that and successfully receive requests from bank and send them requests about sucess or error.