### PR TITLE
Stop sending empty data upstream on 404

### DIFF
--- a/lib/socketServer/lib/clientHttpServer.js
+++ b/lib/socketServer/lib/clientHttpServer.js
@@ -86,7 +86,7 @@ function clientHttpServer(upstream, c) {
           if (req.url == '/') {
             var data = null;
             try {
-              var data = JSON.parse(body);
+              data = JSON.parse(body);
               data = prepareObjectDataIn(data);
             } catch (ex) {
               this.sendReply('', 400, [ex.toString()]);
@@ -94,10 +94,11 @@ function clientHttpServer(upstream, c) {
             }
           // We handle raw hex data at /raw. EG: 30383030303132333435363030303030313233343536313233353637383930313234353637 (0800...)
           } else if (req.url == '/raw') {
-            var data = Buffer.from(body, 'hex');
+            data = Buffer.from(body, 'hex');
             req.isRawMode = true;
           } else {
             this.sendReply('', 404, 'Not Found');
+            return;
           }
           
           var errReturn = [];


### PR DESCRIPTION
It should now exit the on-data callable, as on line 93.